### PR TITLE
add custom pushdata

### DIFF
--- a/bitcash/transaction.py
+++ b/bitcash/transaction.py
@@ -188,14 +188,14 @@ def construct_output_block(outputs, custom_pushdata=False):
 
         # Blockchain storage
         else:
-            if (custom_pushdata is False):
+            if custom_pushdata is False:
                 script = (OP_RETURN +
                           len(dest).to_bytes(1, byteorder='little') +
                           dest)
 
                 output_block += b'\x00\x00\x00\x00\x00\x00\x00\x00'
 
-            elif (custom_pushdata is True):
+            elif custom_pushdata is True:
                 # manual control over number of bytes in each batch of pushdata
                 if type(dest) != bytes:
                     raise TypeError("custom pushdata must be of type: bytes")
@@ -242,10 +242,7 @@ def create_p2pkh_transaction(private_key, unspents, outputs, custom_pushdata=Fal
     input_count = int_to_unknown_bytes(len(unspents), byteorder='little')
     output_count = int_to_unknown_bytes(len(outputs), byteorder='little')
 
-    if (custom_pushdata is False):
-        output_block = construct_output_block(outputs)
-    else:
-        output_block = construct_output_block(outputs, custom_pushdata=True)
+    output_block = construct_output_block(outputs, custom_pushdata=custom_pushdata)
 
     # Optimize for speed, not memory, by pre-computing values.
     inputs = []

--- a/bitcash/wallet.py
+++ b/bitcash/wallet.py
@@ -206,7 +206,7 @@ class PrivateKey(BaseKey):
         return self.transactions
 
     def create_transaction(self, outputs, fee=None, leftover=None, combine=True,
-                           message=None, unspents=None):  # pragma: no cover
+                           message=None, unspents=None, custom_pushdata=False):  # pragma: no cover
         """Creates a signed P2PKH transaction.
 
         :param outputs: A sequence of outputs you wish to send in the form
@@ -246,10 +246,11 @@ class PrivateKey(BaseKey):
             leftover or self.address,
             combine=combine,
             message=message,
-            compressed=self.is_compressed()
+            compressed=self.is_compressed(),
+            custom_pushdata=custom_pushdata
         )
 
-        return create_p2pkh_transaction(self, unspents, outputs)
+        return create_p2pkh_transaction(self, unspents, outputs, custom_pushdata=custom_pushdata)
 
     def send(self, outputs, fee=None, leftover=None, combine=True,
              message=None, unspents=None):  # pragma: no cover
@@ -499,7 +500,7 @@ class PrivateKeyTestnet(BaseKey):
         return self.transactions
 
     def create_transaction(self, outputs, fee=None, leftover=None, combine=True,
-                           message=None, unspents=None):
+                           message=None, unspents=None, custom_pushdata=False):
         """Creates a signed P2PKH transaction.
 
         :param outputs: A sequence of outputs you wish to send in the form
@@ -539,10 +540,11 @@ class PrivateKeyTestnet(BaseKey):
             leftover or self.address,
             combine=combine,
             message=message,
-            compressed=self.is_compressed()
+            compressed=self.is_compressed(),
+            custom_pushdata=custom_pushdata
         )
 
-        return create_p2pkh_transaction(self, unspents, outputs)
+        return create_p2pkh_transaction(self, unspents, outputs, custom_pushdata=custom_pushdata)
 
     def send(self, outputs, fee=None, leftover=None, combine=True,
              message=None, unspents=None):


### PR DESCRIPTION
- Allows fine control over OP_RETURN pushdata e.g. as discrete (variable sized) PUSHDATA elements 
e.g. allows: 6a 02 6d01 0b 68656c6c6f20776f726c64 - (changes memo.cash name to "hello world")
i.e. separate chunks: 2 bytes '6d01' then 11 bytes '68656c6c6f20776f726c64'
- Currently only allows: 6a 0f 3664303168656c6c6f20776f726c64 (i.e. 0x0f bytes as one big chunk of utf-8 encoded data). 
- This is because `len(dest).to_bytes()` is hardcoded into `construct_output_block()` so 0x0f is enforced.
- `custom_pushdata = True` simply gives total freedom over what comes after OP_RETURN. Important for things like SLP protocol (in very active development).