### PR TITLE
fix failed test after increase to 220 byte OP_RETURN

### DIFF
--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -257,7 +257,7 @@ class TestConstructOutputBlock:
     def test_long_message(self):
         amount = b'\x00\x00\x00\x00\x00\x00\x00\x00'
         _, outputs = sanitize_tx_data(
-            UNSPENTS, [(out[0], out[1], 'satoshi') for out in OUTPUTS], 0, RETURN_ADDRESS, message='hello'*9
+            UNSPENTS, [(out[0], out[1], 'satoshi') for out in OUTPUTS], 0, RETURN_ADDRESS, message='hello'*50
         )
         assert construct_output_block(outputs).count(amount) == 2
 


### PR DESCRIPTION
After the increase of MESSAGE_LIMIT from 40 to 220. 
This test no longer passes (because the "hello"*9 is not long enough to overflow and create two OP_RETURNs (each with amount = b'\x00\x00\x00\x00\x00\x00\x00\x00' ).

I have increased the number of "hello"s to 50 (arbitrarily) to make (50 * 5 = 250 characters / bytes).
Now passes.

edit: I have added this to the other PR too so maybe could close this.