### PR TITLE
add accurate_fee_calculation

### DIFF
--- a/bitcash/transaction.py
+++ b/bitcash/transaction.py
@@ -73,7 +73,7 @@ def calc_txid(tx_hex):
     return bytes_to_hex(double_sha256(hex_to_bytes(tx_hex))[::-1])
 
 
-def estimate_tx_fee(n_in, n_out, satoshis, compressed, op_return_size):
+def estimate_tx_fee(n_in, n_out, satoshis, compressed, op_return_size=0):
 
     if not satoshis:
         return 0
@@ -181,7 +181,7 @@ def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True, message=Non
 
         for index, unspent in enumerate(unspents):
             total_in += unspent.amount
-            calculated_fee = estimate_tx_fee(len(unspents[:index + 1]), num_outputs, fee, compressed)
+            calculated_fee = estimate_tx_fee(len(unspents[:index + 1]), num_outputs, fee, compressed, total_op_return_size)
             total_out = sum_outputs + calculated_fee
 
             if total_in >= total_out:

--- a/bitcash/transaction.py
+++ b/bitcash/transaction.py
@@ -103,7 +103,7 @@ def get_op_return_size(message):
         + len(get_op_pushdata_code(message))  # 1 byte if <75 bytes, 2 bytes if OP_PUSHDATA1...
         + len(message)  # Max 220 bytes at present
     )
-    # "Var_Int" that preceeds OP_RETURN - 0xdf is max value with currenlt 220 byte limit (so only adds 1 byte)
+    # "Var_Int" that preceeds OP_RETURN - 0xdf is max value with current 220 byte limit (so only adds 1 byte)
     op_return_size += len(int_to_varint(op_return_size))
     return op_return_size
 


### PR DESCRIPTION
Fees are now calculated accurately down to the last byte for OP_RETURN outputs.
------------------------------------------------------------------------------------------
1 sat/byte should be fine for every transaction on main net with this.
Let me know what you guys think.

see: 
- https://blockchair.com/bitcoin-cash/transaction/e806bc2bcf58312c90c66c09f1d64011509174611e58f66d9ba335e06f2ce5e5
- 404 bytes and 404 satoshis using `my_key.send([], fee=1, message="hello"*40)` - confirmed :)

WARNING: Does not work for custom_pushdata = True yet.
Working on it... time for bed zzz