### PR TITLE
Revert get_balance() flow to use get_unspent()

### DIFF
--- a/bitcash/wallet.py
+++ b/bitcash/wallet.py
@@ -185,7 +185,8 @@ class PrivateKey(BaseKey):
         :type currency: ``str``
         :rtype: ``str``
         """
-        self.balance = NetworkAPI.get_balance(self.address)
+        self.unspents[:] = NetworkAPI.get_unspent(self.address)
+        self.balance = sum(unspent.amount for unspent in self.unspents)
         return self.balance_as(currency)
 
     def get_unspents(self):
@@ -480,7 +481,8 @@ class PrivateKeyTestnet(BaseKey):
         :type currency: ``str``
         :rtype: ``str``
         """
-        self.balance = NetworkAPI.get_balance_testnet(self.address)
+        self.unspents[:] = NetworkAPI.get_unspent_testnet(self.address)
+        self.balance = sum(unspent.amount for unspent in self.unspents)
         return self.balance
 
     def get_unspents(self):


### PR DESCRIPTION
`get_balance()` used to compute the balance from the UTXO set.
I changed this in 0.5.3.1 to get the balance directly from rest.bitcoin.com
but this change might break things.

This commit reverts to the previous method.