### PR TITLE
Fixed documentation auto deploy 

### DIFF
--- a/.travis/deploy_docs.sh
+++ b/.travis/deploy_docs.sh
@@ -4,7 +4,7 @@
 
 set -o errexit -o nounset
 
-if [ "$TRAVIS_REPO_SLUG" != "ofek/bitcash" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "master" ]
+if [ "$TRAVIS_REPO_SLUG" != "merc1er/bitcash" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "docs-deploy" ]
 then
   echo "This commit was made against the $TRAVIS_BRANCH and not the master! No deploy!"
   exit 0
@@ -29,10 +29,10 @@ make html
 cd build/html
 
 git init
-git config user.name "Ofek Lev"
-git config user.email "ofekmeister@gmail.com"
+git config user.name "Corentin Mercier"
+git config user.email "corentin@mercier.link"
 
-git remote add upstream "https://$GH_TOKEN@github.com/ofek/bitcash.git"
+git remote add upstream "https://$GH_TOKEN@github.com/merc1er/bitcash.git"
 git fetch upstream
 git reset upstream/gh-pages
 

--- a/.travis/deploy_docs.sh
+++ b/.travis/deploy_docs.sh
@@ -4,7 +4,7 @@
 
 set -o errexit -o nounset
 
-if [ "$TRAVIS_REPO_SLUG" != "merc1er/bitcash" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "docs-deploy" ]
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "master" ]
 then
   echo "This commit was made against the $TRAVIS_BRANCH and not the master! No deploy!"
   exit 0
@@ -29,10 +29,10 @@ make html
 cd build/html
 
 git init
-git config user.name "Corentin Mercier"
-git config user.email "corentin@mercier.link"
+git config user.name "Teran McKinney"
+git config user.email ""
 
-git remote add upstream "https://$GH_TOKEN@github.com/merc1er/bitcash.git"
+git remote add upstream "https://$GH_TOKEN@github.com/sporestack/bitcash.git"
 git fetch upstream
 git reset upstream/gh-pages
 


### PR DESCRIPTION
Documentation is supposed to be autogenerated via Travis-CI and pushed to `gh-pages` to finally be deployed to https://sporestack.github.io/bitcash/.

This PR fixes `deploy_docs.sh` by changing Ofek's personal username and repo address to Sporestack's.

⚠️ @teran-mckinney you will have to add an environment variable called `GH_TOKEN` to the Travis build, containing your GitHub auth token.  
You might also want to add an email address on line 33 of `deploy_docs.sh`.