### PR TITLE
Fixed `NetworkAPI.get_transaction` and `NetworkAPI.get_transaction_testnet`

### DIFF
--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -99,7 +99,7 @@ class BitcoinDotComAPI():
     MAIN_ADDRESS_API = MAIN_ENDPOINT + 'address/details/{}'
     MAIN_UNSPENT_API = MAIN_ENDPOINT + 'address/utxo/{}'
     MAIN_TX_PUSH_API = MAIN_ENDPOINT + 'rawtransactions/sendRawTransaction/{}'
-    MAIN_TX_API = MAIN_ENDPOINT + 'tx/{}'
+    MAIN_TX_API = MAIN_ENDPOINT + 'transaction/details/{}'
     MAIN_TX_AMOUNT_API = MAIN_TX_API
     MAIN_RAW_API = MAIN_ENDPOINT + 'transaction/details/{}'
     TX_PUSH_PARAM = 'rawtx'
@@ -156,7 +156,7 @@ class BitcoinDotComAPI():
                 (Decimal(response['fees']) * BCH_TO_SAT_MULTIPLIER).normalize())
 
         for txin in response['vin']:
-            part = TxPart(txin['addr'], txin['valueSat'], txin['scriptSig']['asm'])
+            part = TxPart(txin['cashAddress'], txin['value'], txin['scriptSig']['asm'])
             tx.add_input(part)
 
         for txout in response['vout']:

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -146,7 +146,7 @@ class BitcoinDotComAPI():
     @classmethod
     def get_transaction(cls, txid):
         r = requests.get(cls.MAIN_TX_API.format(txid),
-                                            timeout=DEFAULT_TIMEOUT)
+                         timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         response = r.json(parse_float=Decimal)
 
@@ -156,13 +156,15 @@ class BitcoinDotComAPI():
                 (Decimal(response['fees']) * BCH_TO_SAT_MULTIPLIER).normalize())
 
         for txin in response['vin']:
-            part = TxPart(txin['cashAddress'], txin['value'], txin['scriptSig']['asm'])
+            part = TxPart(txin['cashAddress'],
+                          txin['value'],
+                          txin['scriptSig']['asm'])
             tx.add_input(part)
 
         for txout in response['vout']:
             addr = None
-            if 'addresses' in txout['scriptPubKey'] and txout['scriptPubKey']['addresses'] is not None:
-                addr = txout['scriptPubKey']['addresses'][0]
+            if 'cashAddrs' in txout['scriptPubKey'] and txout['scriptPubKey']['cashAddrs'] is not None:
+                addr = txout['scriptPubKey']['cashAddrs'][0]
 
             part = TxPart(addr,
                     (Decimal(txout['value']) * BCH_TO_SAT_MULTIPLIER).normalize(),

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -43,37 +43,6 @@ class InsightAPI:
         return r.json()['transactions']
 
     @classmethod
-    def get_transaction(cls, txid):
-        r = requests.get(cls.MAIN_TX_API.format(txid), timeout=DEFAULT_TIMEOUT)
-        r.raise_for_status()  # pragma: no cover
-        response = r.json(parse_float=Decimal)
-
-        tx = Transaction(response['txid'], response['blockheight'],
-                         (Decimal(response['valueIn']) *
-                          BCH_TO_SAT_MULTIPLIER).normalize(),
-                         (Decimal(response['valueOut']) *
-                          BCH_TO_SAT_MULTIPLIER).normalize(),
-                         (Decimal(response['fees']) * BCH_TO_SAT_MULTIPLIER).normalize())
-
-        for txin in response['vin']:
-            part = TxPart(txin['addr'], txin['valueSat'],
-                          txin['scriptSig']['asm'])
-            tx.add_input(part)
-
-        for txout in response['vout']:
-            addr = None
-            if 'addresses' in txout['scriptPubKey'] and txout['scriptPubKey']['addresses'] is not None:
-                addr = txout['scriptPubKey']['addresses'][0]
-
-            part = TxPart(addr,
-                          (Decimal(txout['value']) *
-                           BCH_TO_SAT_MULTIPLIER).normalize(),
-                          txout['scriptPubKey']['asm'])
-            tx.add_output(part)
-
-        return tx
-
-    @classmethod
     def get_tx_amount(cls, txid, txindex):
         r = requests.get(cls.MAIN_TX_AMOUNT_API.format(
             txid), timeout=DEFAULT_TIMEOUT)
@@ -397,8 +366,7 @@ class NetworkAPI:
                         BitcoreAPI.get_unspent]
     BROADCAST_TX_MAIN = [BitcoinDotComAPI.broadcast_tx,
                          BitcoreAPI.broadcast_tx]
-    GET_TX_MAIN = [BitcoinDotComAPI.get_transaction,
-                   BitcoreAPI.get_transaction]
+    GET_TX_MAIN = [BitcoinDotComAPI.get_transaction]
     GET_TX_AMOUNT_MAIN = [BitcoinDotComAPI.get_tx_amount,
                           BitcoreAPI.get_tx_amount]
     GET_RAW_TX_MAIN = [BitcoinDotComAPI.get_raw_transaction]

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -30,13 +30,15 @@ class InsightAPI:
 
     @classmethod
     def get_balance(cls, address):
-        r = requests.get(cls.MAIN_BALANCE_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.MAIN_BALANCE_API.format(
+            address), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return r.json()
 
     @classmethod
     def get_transactions(cls, address):
-        r = requests.get(cls.MAIN_ADDRESS_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.MAIN_ADDRESS_API.format(
+            address), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return r.json()['transactions']
 
@@ -47,12 +49,15 @@ class InsightAPI:
         response = r.json(parse_float=Decimal)
 
         tx = Transaction(response['txid'], response['blockheight'],
-                (Decimal(response['valueIn']) * BCH_TO_SAT_MULTIPLIER).normalize(),
-                (Decimal(response['valueOut']) * BCH_TO_SAT_MULTIPLIER).normalize(),
-                (Decimal(response['fees']) * BCH_TO_SAT_MULTIPLIER).normalize())
+                         (Decimal(response['valueIn']) *
+                          BCH_TO_SAT_MULTIPLIER).normalize(),
+                         (Decimal(response['valueOut']) *
+                          BCH_TO_SAT_MULTIPLIER).normalize(),
+                         (Decimal(response['fees']) * BCH_TO_SAT_MULTIPLIER).normalize())
 
         for txin in response['vin']:
-            part = TxPart(txin['addr'], txin['valueSat'], txin['scriptSig']['asm'])
+            part = TxPart(txin['addr'], txin['valueSat'],
+                          txin['scriptSig']['asm'])
             tx.add_input(part)
 
         for txout in response['vout']:
@@ -61,22 +66,25 @@ class InsightAPI:
                 addr = txout['scriptPubKey']['addresses'][0]
 
             part = TxPart(addr,
-                    (Decimal(txout['value']) * BCH_TO_SAT_MULTIPLIER).normalize(),
-                    txout['scriptPubKey']['asm'])
+                          (Decimal(txout['value']) *
+                           BCH_TO_SAT_MULTIPLIER).normalize(),
+                          txout['scriptPubKey']['asm'])
             tx.add_output(part)
 
         return tx
 
     @classmethod
     def get_tx_amount(cls, txid, txindex):
-        r = requests.get(cls.MAIN_TX_AMOUNT_API.format(txid), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.MAIN_TX_AMOUNT_API.format(
+            txid), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         response = r.json(parse_float=Decimal)
         return (Decimal(response['vout'][txindex]['value']) * BCH_TO_SAT_MULTIPLIER).normalize()
 
     @classmethod
     def get_unspent(cls, address):
-        r = requests.get(cls.MAIN_UNSPENT_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.MAIN_UNSPENT_API.format(
+            address), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return [
             Unspent(currency_to_satoshi(tx['amount'], 'bch'),
@@ -89,7 +97,8 @@ class InsightAPI:
 
     @classmethod
     def broadcast_tx(cls, tx_hex):  # pragma: no cover
-        r = requests.post(cls.MAIN_TX_PUSH_API, json={cls.TX_PUSH_PARAM: tx_hex, 'network': 'mainnet', 'coin': 'BCH'}, timeout=DEFAULT_TIMEOUT)
+        r = requests.post(cls.MAIN_TX_PUSH_API, json={
+                          cls.TX_PUSH_PARAM: tx_hex, 'network': 'mainnet', 'coin': 'BCH'}, timeout=DEFAULT_TIMEOUT)
         return True if r.status_code == 200 else False
 
 
@@ -114,7 +123,7 @@ class BitcoinDotComAPI():
     @classmethod
     def get_balance(cls, address):
         r = requests.get(cls.MAIN_ADDRESS_API.format(address),
-                                            timeout=DEFAULT_TIMEOUT)
+                         timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         data = r.json()
         balance = data['balanceSat'] + data['unconfirmedBalanceSat']
@@ -123,7 +132,7 @@ class BitcoinDotComAPI():
     @classmethod
     def get_balance_testnet(cls, address):
         r = requests.get(cls.TEST_ADDRESS_API.format(address),
-                                            timeout=DEFAULT_TIMEOUT)
+                         timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         data = r.json()
         balance = data['balanceSat'] + data['unconfirmedBalanceSat']
@@ -132,14 +141,14 @@ class BitcoinDotComAPI():
     @classmethod
     def get_transactions(cls, address):
         r = requests.get(cls.MAIN_ADDRESS_API.format(address),
-                                            timeout=DEFAULT_TIMEOUT)
+                         timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return r.json()['transactions']
 
     @classmethod
     def get_transactions_testnet(cls, address):
         r = requests.get(cls.TEST_ADDRESS_API.format(address),
-                                            timeout=DEFAULT_TIMEOUT)
+                         timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return r.json()['transactions']
 
@@ -151,9 +160,11 @@ class BitcoinDotComAPI():
         response = r.json(parse_float=Decimal)
 
         tx = Transaction(response['txid'], response['blockheight'],
-                (Decimal(response['valueIn']) * BCH_TO_SAT_MULTIPLIER).normalize(),
-                (Decimal(response['valueOut']) * BCH_TO_SAT_MULTIPLIER).normalize(),
-                (Decimal(response['fees']) * BCH_TO_SAT_MULTIPLIER).normalize())
+                         (Decimal(response['valueIn']) *
+                          BCH_TO_SAT_MULTIPLIER).normalize(),
+                         (Decimal(response['valueOut']) *
+                          BCH_TO_SAT_MULTIPLIER).normalize(),
+                         (Decimal(response['fees']) * BCH_TO_SAT_MULTIPLIER).normalize())
 
         for txin in response['vin']:
             part = TxPart(txin['cashAddress'],
@@ -167,15 +178,17 @@ class BitcoinDotComAPI():
                 addr = txout['scriptPubKey']['cashAddrs'][0]
 
             part = TxPart(addr,
-                    (Decimal(txout['value']) * BCH_TO_SAT_MULTIPLIER).normalize(),
-                    txout['scriptPubKey']['asm'])
+                          (Decimal(txout['value']) *
+                           BCH_TO_SAT_MULTIPLIER).normalize(),
+                          txout['scriptPubKey']['asm'])
             tx.add_output(part)
 
         return tx
 
     @classmethod
     def get_tx_amount(cls, txid, txindex):
-        r = requests.get(cls.MAIN_TX_AMOUNT_API.format(txid), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.MAIN_TX_AMOUNT_API.format(
+            txid), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         response = r.json(parse_float=Decimal)
         return (Decimal(response['vout'][txindex]['value']) * BCH_TO_SAT_MULTIPLIER).normalize()
@@ -183,7 +196,7 @@ class BitcoinDotComAPI():
     @classmethod
     def get_unspent(cls, address):
         r = requests.get(cls.MAIN_UNSPENT_API.format(address),
-                                            timeout=DEFAULT_TIMEOUT)
+                         timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return [
             Unspent(currency_to_satoshi(tx['amount'], 'bch'),
@@ -197,7 +210,7 @@ class BitcoinDotComAPI():
     @classmethod
     def get_unspent_testnet(cls, address):
         r = requests.get(cls.TEST_UNSPENT_API.format(address),
-                                            timeout=DEFAULT_TIMEOUT)
+                         timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return [
             Unspent(currency_to_satoshi(tx['amount'], 'bch'),
@@ -210,14 +223,16 @@ class BitcoinDotComAPI():
 
     @classmethod
     def get_raw_transaction(cls, txid):
-        r = requests.get(cls.MAIN_RAW_API.format(txid), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.MAIN_RAW_API.format(
+            txid), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         response = r.json(parse_float=Decimal)
         return response
 
     @classmethod
     def get_raw_transaction_testnet(cls, txid):
-        r = requests.get(cls.TEST_RAW_API.format(txid), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.TEST_RAW_API.format(
+            txid), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         response = r.json(parse_float=Decimal)
         return response
@@ -254,7 +269,8 @@ class BitcoreAPI(InsightAPI):
     @classmethod
     def get_unspent(cls, address):
         address = address.replace('bitcoincash:', '')
-        r = requests.get(cls.MAIN_UNSPENT_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.MAIN_UNSPENT_API.format(
+            address), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return [
             Unspent(currency_to_satoshi(tx['value'], 'satoshi'),
@@ -268,26 +284,30 @@ class BitcoreAPI(InsightAPI):
     @classmethod
     def get_transactions(cls, address):
         address = address.replace('bitcoincash:', '')
-        r = requests.get(cls.MAIN_ADDRESS_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.MAIN_ADDRESS_API.format(
+            address), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return [tx['mintTxid'] for tx in r.json()]
 
     @classmethod
     def get_balance(cls, address):
-        r = requests.get(cls.MAIN_BALANCE_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.MAIN_BALANCE_API.format(
+            address), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return r.json()['balance']
 
     @classmethod
     def get_balance_testnet(cls, address):
-        r = requests.get(cls.TEST_BALANCE_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.TEST_BALANCE_API.format(
+            address), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return r.json()['balance']
 
     @classmethod
     def get_transactions_testnet(cls, address):
         address = address.replace('bchtest:', '')
-        r = requests.get(cls.TEST_ADDRESS_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.TEST_ADDRESS_API.format(
+            address), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         return [tx['mintTxid'] for tx in r.json()]
 
@@ -298,12 +318,15 @@ class BitcoreAPI(InsightAPI):
         response = r.json(parse_float=Decimal)
 
         tx = Transaction(response['txid'], response['blockheight'],
-                (Decimal(response['valueIn']) * BCH_TO_SAT_MULTIPLIER).normalize(),
-                (Decimal(response['valueOut']) * BCH_TO_SAT_MULTIPLIER).normalize(),
-                (Decimal(response['fees']) * BCH_TO_SAT_MULTIPLIER).normalize())
+                         (Decimal(response['valueIn']) *
+                          BCH_TO_SAT_MULTIPLIER).normalize(),
+                         (Decimal(response['valueOut']) *
+                          BCH_TO_SAT_MULTIPLIER).normalize(),
+                         (Decimal(response['fees']) * BCH_TO_SAT_MULTIPLIER).normalize())
 
         for txin in response['vin']:
-            part = TxPart(txin['addr'], txin['valueSat'], txin['scriptSig']['asm'])
+            part = TxPart(txin['addr'], txin['valueSat'],
+                          txin['scriptSig']['asm'])
             tx.add_input(part)
 
         for txout in response['vout']:
@@ -312,23 +335,27 @@ class BitcoreAPI(InsightAPI):
                 addr = txout['scriptPubKey']['addresses'][0]
 
             part = TxPart(addr,
-                    (Decimal(txout['value']) * BCH_TO_SAT_MULTIPLIER).normalize(),
-                    txout['scriptPubKey']['asm'])
+                          (Decimal(txout['value']) *
+                           BCH_TO_SAT_MULTIPLIER).normalize(),
+                          txout['scriptPubKey']['asm'])
             tx.add_output(part)
 
         return tx
 
     @classmethod
     def get_tx_amount_testnet(cls, txid, txindex):
-        r = requests.get(cls.TEST_TX_AMOUNT_API.format(txid), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.TEST_TX_AMOUNT_API.format(
+            txid), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         response = r.json(parse_float=Decimal)
-        return (Decimal(response['vout'][txindex]['value']) * BCH_TO_SAT_MULTIPLIER).normalize()
+        return (Decimal(response['vout'][txindex]['value']) *
+                BCH_TO_SAT_MULTIPLIER).normalize()
 
     @classmethod
     def get_unspent_testnet(cls, address):
         address = address.replace('bchtest:', '')
-        r = requests.get(cls.TEST_UNSPENT_API.format(address), timeout=DEFAULT_TIMEOUT)
+        r = requests.get(cls.TEST_UNSPENT_API.format(
+            address), timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         unspents = []
         for tx in r.json():
@@ -349,7 +376,10 @@ class BitcoreAPI(InsightAPI):
 
     @classmethod
     def broadcast_tx_testnet(cls, tx_hex):  # pragma: no cover
-        r = requests.post(cls.TEST_TX_PUSH_API, json={cls.TX_PUSH_PARAM: tx_hex, 'network': 'testnet', 'coin': 'BCH'}, timeout=DEFAULT_TIMEOUT)
+        r = requests.post(cls.TEST_TX_PUSH_API, json={
+                          cls.TX_PUSH_PARAM: tx_hex,
+                          'network': 'testnet',
+                          'coin': 'BCH'}, timeout=DEFAULT_TIMEOUT)
         return True if r.status_code == 200 else False
 
 
@@ -374,12 +404,12 @@ class NetworkAPI:
     GET_RAW_TX_MAIN = [BitcoinDotComAPI.get_raw_transaction]
 
     GET_BALANCE_TEST = [BitcoinDotComAPI.get_balance_testnet,
-                            BitcoreAPI.get_balance_testnet]
+                        BitcoreAPI.get_balance_testnet]
     GET_TRANSACTIONS_TEST = [BitcoreAPI.get_transactions_testnet]
     GET_UNSPENT_TEST = [BitcoinDotComAPI.get_unspent_testnet,
-                                BitcoreAPI.get_unspent_testnet]
+                        BitcoreAPI.get_unspent_testnet]
     BROADCAST_TX_TEST = [BitcoinDotComAPI.broadcast_tx_testnet,
-                                BitcoreAPI.broadcast_tx_testnet]
+                         BitcoreAPI.broadcast_tx_testnet]
     GET_TX_TEST = [BitcoreAPI.get_transaction_testnet]
     GET_TX_AMOUNT_TEST = [BitcoreAPI.get_tx_amount_testnet]
     GET_RAW_TX_TEST = [BitcoinDotComAPI.get_raw_transaction_testnet]

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -85,7 +85,7 @@ class BitcoinDotComAPI():
     TEST_ADDRESS_API = TEST_ENDPOINT + 'address/details/{}'
     TEST_UNSPENT_API = TEST_ENDPOINT + 'address/utxo/{}'
     TEST_TX_PUSH_API = TEST_ENDPOINT + '/rawtransactions/sendRawTransaction/{}'
-    TEST_TX_API = MAIN_TX_API
+    TEST_TX_API = TEST_ENDPOINT + 'transaction/details/{}'
     TEST_TX_AMOUNT_API = TEST_TX_API
     TEST_RAW_API = TEST_ENDPOINT + 'transaction/details/{}'
 
@@ -124,6 +124,39 @@ class BitcoinDotComAPI():
     @classmethod
     def get_transaction(cls, txid):
         r = requests.get(cls.MAIN_TX_API.format(txid),
+                         timeout=DEFAULT_TIMEOUT)
+        r.raise_for_status()  # pragma: no cover
+        response = r.json(parse_float=Decimal)
+
+        tx = Transaction(response['txid'], response['blockheight'],
+                         (Decimal(response['valueIn']) *
+                          BCH_TO_SAT_MULTIPLIER).normalize(),
+                         (Decimal(response['valueOut']) *
+                          BCH_TO_SAT_MULTIPLIER).normalize(),
+                         (Decimal(response['fees']) * BCH_TO_SAT_MULTIPLIER).normalize())
+
+        for txin in response['vin']:
+            part = TxPart(txin['cashAddress'],
+                          txin['value'],
+                          txin['scriptSig']['asm'])
+            tx.add_input(part)
+
+        for txout in response['vout']:
+            addr = None
+            if 'cashAddrs' in txout['scriptPubKey'] and txout['scriptPubKey']['cashAddrs'] is not None:
+                addr = txout['scriptPubKey']['cashAddrs'][0]
+
+            part = TxPart(addr,
+                          (Decimal(txout['value']) *
+                           BCH_TO_SAT_MULTIPLIER).normalize(),
+                          txout['scriptPubKey']['asm'])
+            tx.add_output(part)
+
+        return tx
+
+    @classmethod
+    def get_transaction_testnet(cls, txid):
+        r = requests.get(cls.TEST_TX_API.format(txid),
                          timeout=DEFAULT_TIMEOUT)
         r.raise_for_status()  # pragma: no cover
         response = r.json(parse_float=Decimal)
@@ -281,37 +314,6 @@ class BitcoreAPI(InsightAPI):
         return [tx['mintTxid'] for tx in r.json()]
 
     @classmethod
-    def get_transaction_testnet(cls, txid):
-        r = requests.get(cls.TEST_TX_API.format(txid), timeout=DEFAULT_TIMEOUT)
-        r.raise_for_status()  # pragma: no cover
-        response = r.json(parse_float=Decimal)
-
-        tx = Transaction(response['txid'], response['blockheight'],
-                         (Decimal(response['valueIn']) *
-                          BCH_TO_SAT_MULTIPLIER).normalize(),
-                         (Decimal(response['valueOut']) *
-                          BCH_TO_SAT_MULTIPLIER).normalize(),
-                         (Decimal(response['fees']) * BCH_TO_SAT_MULTIPLIER).normalize())
-
-        for txin in response['vin']:
-            part = TxPart(txin['addr'], txin['valueSat'],
-                          txin['scriptSig']['asm'])
-            tx.add_input(part)
-
-        for txout in response['vout']:
-            addr = None
-            if 'addresses' in txout['scriptPubKey'] and txout['scriptPubKey']['addresses'] is not None:
-                addr = txout['scriptPubKey']['addresses'][0]
-
-            part = TxPart(addr,
-                          (Decimal(txout['value']) *
-                           BCH_TO_SAT_MULTIPLIER).normalize(),
-                          txout['scriptPubKey']['asm'])
-            tx.add_output(part)
-
-        return tx
-
-    @classmethod
     def get_tx_amount_testnet(cls, txid, txindex):
         r = requests.get(cls.TEST_TX_AMOUNT_API.format(
             txid), timeout=DEFAULT_TIMEOUT)
@@ -378,7 +380,7 @@ class NetworkAPI:
                         BitcoreAPI.get_unspent_testnet]
     BROADCAST_TX_TEST = [BitcoinDotComAPI.broadcast_tx_testnet,
                          BitcoreAPI.broadcast_tx_testnet]
-    GET_TX_TEST = [BitcoreAPI.get_transaction_testnet]
+    GET_TX_TEST = [BitcoinDotComAPI.get_transaction_testnet]
     GET_TX_AMOUNT_TEST = [BitcoreAPI.get_tx_amount_testnet]
     GET_RAW_TX_TEST = [BitcoinDotComAPI.get_raw_transaction_testnet]
 

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -17,6 +17,7 @@ TEST_ADDRESS_USED2 = 'qprralpnpx6zrx3w2aet97u0c6rcfrlp8v6jenepj5'
 TEST_ADDRESS_USED3 = 'qpjm4n7m4r6aufkxxy5nqm5letejdm4f5sn6an6rsl'
 TEST_ADDRESS_UNUSED = 'qpwn6qz29s5rv2uf0cxd7ygnwdttsuschczaz38yc5'
 TEST_TX = '09d0c9773c56fac218ae084226e9db8480d9b5c6f60cc0466431d6820d344adc'
+TEST_TX2 = '3c26deab2df023a8dbee15bf47701332f6661323ea117a58362b0ea9605129fd'
 
 
 def all_items_common(seq):
@@ -127,6 +128,12 @@ class TestBitcoinDotComAPI:
 
     def test_get_transactions_main_unused(self):
         assert len(BitcoinDotComAPI.get_transactions(MAIN_ADDRESS_UNUSED)) == 0
+
+    def test_get_transaction(self):
+        assert len(str(BitcoinDotComAPI.get_transaction(MAIN_TX))) >= 156
+
+    def test_get_transaction_testnet(self):
+        assert len(str(BitcoinDotComAPI.get_transaction_testnet(TEST_TX2))) >= 156
 
     def test_get_transactions_test_used(self):
         assert len(BitcoinDotComAPI.get_transactions_testnet(TEST_ADDRESS_USED2)) >= 444


### PR DESCRIPTION
- Note that there is no redundancy for this. Both methods use **only** rest.Bitcoin.com as the data given by BitcoreAPI at `https://api.bitcore.io/api/BCH/mainnet/tx/{your_tx}` is not satisfactory.

- Basic tests are implemented

- ⚠️ This will **not** work for coinbase transactions as I cannot create a `Transaction` instance with a coinbase transaction without changing the class definition.

See in `network/transaction.py` line 12:
```python
if amount_in != amount_out + amount_fee:
            raise ArithmeticError("the amounts just don't add up!")
```

- Some tests:
```python
import bitcash

bitcash.network.NetworkAPI.get_transaction('0d840c0351f554fa2579e7d47c025ab5d22eb1d4ca34126b7eaa8f5195a2a849')
bitcash.network.NetworkAPI.get_transaction_testnet('37e22c74c09f61a03d4e9fd64602c716fa65377cf3561dc9bab7ac12a25483ee')
bitcash.network.NetworkAPI.get_transaction('b3367d870688b248b862798fcc7c4ae932836270971ac0a72fb3433b711e8c2d')
bitcash.network.NetworkAPI.get_transaction('c9f79ea7af39d4fb854284439e1fa25c43a90333b47dbc744cb2ca9b1b43a6a6')
```