### PR TITLE
 Fix fallback API not being triggered

### DIFF
--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -354,10 +354,7 @@ class BitcoreAPI(InsightAPI):
 
 
 class NetworkAPI:
-    IGNORED_ERRORS = (ConnectionError,
-                      requests.exceptions.ConnectionError,
-                      requests.exceptions.Timeout,
-                      requests.exceptions.ReadTimeout)
+    IGNORED_ERRORS = (Exception)
 
     # Mainnet
     GET_BALANCE_MAIN = [BitcoinDotComAPI.get_balance,

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -359,6 +359,7 @@ class NetworkAPI:
                       requests.exceptions.Timeout,
                       requests.exceptions.ReadTimeout)
 
+    # Mainnet
     GET_BALANCE_MAIN = [BitcoinDotComAPI.get_balance,
                         BitcoreAPI.get_balance]
     GET_TRANSACTIONS_MAIN = [BitcoinDotComAPI.get_transactions,
@@ -372,6 +373,7 @@ class NetworkAPI:
                           BitcoreAPI.get_tx_amount]
     GET_RAW_TX_MAIN = [BitcoinDotComAPI.get_raw_transaction]
 
+    # Testnet
     GET_BALANCE_TEST = [BitcoinDotComAPI.get_balance_testnet,
                         BitcoreAPI.get_balance_testnet]
     GET_TRANSACTIONS_TEST = [BitcoreAPI.get_transactions_testnet]

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -1,7 +1,6 @@
 import logging
 
 import requests
-from cashaddress import convert as cashaddress
 from decimal import Decimal
 
 from bitcash.network import currency_to_satoshi

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -354,7 +354,20 @@ class BitcoreAPI(InsightAPI):
 
 
 class NetworkAPI:
-    IGNORED_ERRORS = (Exception)
+    IGNORED_ERRORS = (
+        requests.exceptions.RequestException,
+        requests.exceptions.HTTPError,
+        requests.exceptions.ConnectionError,
+        requests.exceptions.ProxyError,
+        requests.exceptions.SSLError,
+        requests.exceptions.Timeout,
+        requests.exceptions.ConnectTimeout,
+        requests.exceptions.ReadTimeout,
+        requests.exceptions.TooManyRedirects,
+        requests.exceptions.ChunkedEncodingError,
+        requests.exceptions.ContentDecodingError,
+        requests.exceptions.StreamConsumedError,
+    )
 
     # Mainnet
     GET_BALANCE_MAIN = [BitcoinDotComAPI.get_balance,


### PR DESCRIPTION
⚠️ There may be a safer way to do this ⚠️

This PR addresses #63. The problem was that the `NetworkAPI.IGNORED_ERRORS` variable did not include many errors like server not reachable, 400 etc...

To fix it, I included ALL exceptions in `IGNORED_ERRORS`, as we want the fallback to be triggered no matter what the error is, except one in the codebase (the latter is yet to be implemented).