### PR TITLE
Swap Bitcore and Bitcoin.com for testnet API calls

### DIFF
--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -384,13 +384,13 @@ class NetworkAPI:
     GET_RAW_TX_MAIN = [BitcoinDotComAPI.get_raw_transaction]
 
     # Testnet
-    GET_BALANCE_TEST = [BitcoinDotComAPI.get_balance_testnet,
-                        BitcoreAPI.get_balance_testnet]
+    GET_BALANCE_TEST = [BitcoreAPI.get_balance_testnet,
+                        BitcoinDotComAPI.get_balance_testnet]
     GET_TRANSACTIONS_TEST = [BitcoreAPI.get_transactions_testnet]
-    GET_UNSPENT_TEST = [BitcoinDotComAPI.get_unspent_testnet,
-                        BitcoreAPI.get_unspent_testnet]
-    BROADCAST_TX_TEST = [BitcoinDotComAPI.broadcast_tx_testnet,
-                         BitcoreAPI.broadcast_tx_testnet]
+    GET_UNSPENT_TEST = [BitcoreAPI.get_unspent_testnet,
+                        BitcoinDotComAPI.get_unspent_testnet]
+    BROADCAST_TX_TEST = [BitcoreAPI.broadcast_tx_testnet,
+                         BitcoinDotComAPI.broadcast_tx_testnet]
     GET_TX_TEST = [BitcoinDotComAPI.get_transaction_testnet]
     GET_TX_AMOUNT_TEST = [BitcoreAPI.get_tx_amount_testnet]
     GET_RAW_TX_TEST = [BitcoinDotComAPI.get_raw_transaction_testnet]


### PR DESCRIPTION
As trest.Bitcoin.com has been highly unreliable.

Note: get_tx() and get_raw_tx() seem to be only available on Bitcoin.com.