### PR TITLE
Fix endpoint error handling for unreliable APIs

### DIFF
--- a/bitcash/exceptions.py
+++ b/bitcash/exceptions.py
@@ -14,5 +14,9 @@ class InvalidEndpointURLProvided(Exception):
     pass
 
 
+class InvalidEndpointResponse(Exception):
+    pass
+
+
 class InvalidCashToken(ValueError):
     pass

--- a/bitcash/exceptions.py
+++ b/bitcash/exceptions.py
@@ -18,5 +18,9 @@ class InvalidEndpointResponse(Exception):
     pass
 
 
+class DataNotFound(Exception):
+    pass
+
+
 class InvalidCashToken(ValueError):
     pass

--- a/bitcash/network/APIs/ChaingraphAPI.py
+++ b/bitcash/network/APIs/ChaingraphAPI.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 from bitcash.network.http import session
-from bitcash.exceptions import InvalidEndpointURLProvided
+from bitcash.exceptions import InvalidEndpointURLProvided, InvalidEndpointResponse
 from bitcash.network.APIs import BaseAPI, SubscriptionHandle
 from bitcash.network.meta import Unspent
 from bitcash.network.transaction import Transaction, TxPart
@@ -53,7 +53,7 @@ class ChaingraphAPI(BaseAPI):
         r.raise_for_status()
         json = r.json()
         if "errors" in json:
-            raise RuntimeError(json)
+            raise InvalidEndpointResponse(json)
         return json
 
     @classmethod
@@ -78,8 +78,12 @@ query GetBlockheight($node: String!) {
             },
         }
         json = self.send_request(json_request, *args, **kwargs)
-        blockheight = int(json["data"]["block"][0]["height"])
-        return blockheight
+        block = json["data"]["block"]
+        if not block:
+            # No blocks returned means the node hasn't indexed any blocks yet.
+            # Return 0 so NetworkAPI's endpoint selection skips this endpoint.
+            return 0
+        return int(block[0]["height"])
 
     def get_balance(self, address: str, *args, **kwargs) -> int:
         json_request = {

--- a/bitcash/network/APIs/ChaingraphAPI.py
+++ b/bitcash/network/APIs/ChaingraphAPI.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 from bitcash.network.http import session
-from bitcash.exceptions import InvalidEndpointURLProvided, InvalidEndpointResponse
+from bitcash.exceptions import InvalidEndpointURLProvided, InvalidEndpointResponse, DataNotFound
 from bitcash.network.APIs import BaseAPI, SubscriptionHandle
 from bitcash.network.meta import Unspent
 from bitcash.network.transaction import Transaction, TxPart
@@ -294,7 +294,7 @@ query GetOutput($tx: bytea!, $txind: bigint!, $node: String!) {
         }
         json = self.send_request(json_request, *args, **kwargs)
         if len(json["data"]["output"]) == 0:
-            raise RuntimeError(f"Output {txid}:{txindex} does not exist")
+            raise DataNotFound(f"Output {txid}:{txindex} does not exist")
         return int(json["data"]["output"][0]["value_satoshis"])
 
     def get_unspent(self, address: str, *args, **kwargs) -> list[Unspent]:
@@ -440,7 +440,7 @@ query GetTransactionDetails($tx: bytea!, $node: String!) {
         }
         json = self.send_request(json_request, *args, **kwargs)
         if len(json["data"]["transaction"]) == 0:
-            raise RuntimeError(f"Transaction {txid} does not exist")
+            raise DataNotFound(f"Transaction {txid} does not exist")
         return json["data"]["transaction"][0]
 
     def broadcast_tx(self, tx_hex: str, *args, **kwargs) -> bool:  # pragma: no cover

--- a/bitcash/network/APIs/FulcrumProtocolAPI.py
+++ b/bitcash/network/APIs/FulcrumProtocolAPI.py
@@ -9,7 +9,7 @@ import typing
 from requests.exceptions import ConnectTimeout, ContentDecodingError
 from typing import Any, Callable, Union
 
-from bitcash.exceptions import InvalidEndpointURLProvided, InvalidEndpointResponse
+from bitcash.exceptions import InvalidEndpointURLProvided, InvalidEndpointResponse, DataNotFound
 from bitcash.network.APIs import BaseAPI, SubscriptionHandle
 from bitcash.network.meta import Unspent
 from bitcash.network.transaction import Transaction, TxPart
@@ -243,7 +243,7 @@ class FulcrumProtocolAPI(BaseAPI):
         for vout in result["vout"]:
             if vout["n"] == txindex:
                 return vout
-        raise RuntimeError(f"Transaction {txid=} doesn't have {txindex=}")
+        raise DataNotFound(f"Transaction {txid=} doesn't have {txindex=}")
 
     def get_tx_amount(self, txid: str, txindex: int, *args, **kwargs) -> int:
         result = self.get_raw_transaction(txid, *args, **kwargs)
@@ -256,7 +256,7 @@ class FulcrumProtocolAPI(BaseAPI):
                     (Decimal(vout["value"]) * BCH_TO_SAT_MULTIPLIER).to_integral_value()
                 )
                 return sats
-        raise RuntimeError(f"Transaction {txid=} doesn't have {txindex=}")
+        raise DataNotFound(f"Transaction {txid=} doesn't have {txindex=}")
 
     def get_unspent(self, address: str, *args, **kwargs) -> list[Unspent]:
         result = self._send_rpc(

--- a/bitcash/network/APIs/FulcrumProtocolAPI.py
+++ b/bitcash/network/APIs/FulcrumProtocolAPI.py
@@ -9,7 +9,7 @@ import typing
 from requests.exceptions import ConnectTimeout, ContentDecodingError
 from typing import Any, Callable, Union
 
-from bitcash.exceptions import InvalidEndpointURLProvided
+from bitcash.exceptions import InvalidEndpointURLProvided, InvalidEndpointResponse
 from bitcash.network.APIs import BaseAPI, SubscriptionHandle
 from bitcash.network.meta import Unspent
 from bitcash.network.transaction import Transaction, TxPart
@@ -82,7 +82,7 @@ def send_json_rpc_payload(
         )
 
     if "error" in return_json:
-        raise RuntimeError(f"Error in retruned json: {return_json['error']}")
+        raise InvalidEndpointResponse(f"Error in returned json: {return_json['error']}")
 
     return return_json["result"]
 

--- a/bitcash/network/APIs/__init__.py
+++ b/bitcash/network/APIs/__init__.py
@@ -65,6 +65,8 @@ class BaseAPI(ABC):
         :param txid: The transaction id in question.
         :param txindex: The transaction index in question.
         :returns: The amount in satoshis.
+        :raises DataNotFound: If the transaction or output index does not
+            exist on this endpoint.
         """
 
     @abstractmethod
@@ -91,6 +93,8 @@ class BaseAPI(ABC):
 
         :param txid: The transaction id in question.
         :returns: The raw transaction details as a dictionary.
+        :raises DataNotFound: If the transaction does not exist on this
+            endpoint.
         """
 
     @abstractmethod

--- a/bitcash/network/APIs/__init__.py
+++ b/bitcash/network/APIs/__init__.py
@@ -31,9 +31,14 @@ class BaseAPI(ABC):
     @abstractmethod
     def get_blockheight(self, *args, **kwargs) -> int:
         """
-        Returns the current block height
+        Returns the current block height.
 
-        :returns: Current block height
+        Must return 0 if the endpoint has not yet indexed any blocks (e.g. a
+        node that hasn't synced). A return value of 0 causes NetworkAPI's
+        endpoint selection to ignore this endpoint, so no further requests
+        will be routed to it until it catches up.
+
+        :returns: Current block height, or 0 if no blocks are available.
         """
 
     @abstractmethod

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -10,6 +10,7 @@ from typing import Any, Callable
 import requests
 
 from bitcash.network.APIs import BaseAPI, SubscriptionHandle
+from bitcash.exceptions import InvalidEndpointResponse
 
 # Import supported endpoint APIs
 from bitcash.network.APIs.BitcoinDotComAPI import BitcoinDotComAPI
@@ -182,6 +183,7 @@ def get_sanitized_endpoints_for(network: NetworkStr = "mainnet") -> tuple[BaseAP
 class NetworkAPI:
     IGNORED_ERRORS = (
         NotImplementedError,
+        InvalidEndpointResponse,
         requests.exceptions.RequestException,
         requests.exceptions.HTTPError,
         requests.exceptions.ConnectionError,

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -274,6 +274,8 @@ class NetworkAPI:
         :param txindex: The transaction index in question.
         :returns: The amount in satoshi.
         :raises ConnectionError: If all API services fail.
+        :raises DataNotFound: If the transaction or output index does not
+            exist on any endpoint. Not caught by endpoint fallback logic.
         """
 
         for endpoint in get_sanitized_endpoints_for(network):
@@ -313,6 +315,8 @@ class NetworkAPI:
         :param txid: The transaction id in question.
         :returns: The raw transaction details.
         :raises ConnectionError: If all API services fail.
+        :raises DataNotFound: If the transaction does not exist on any
+            endpoint. Not caught by endpoint fallback logic.
         """
 
         for endpoint in get_sanitized_endpoints_for(network):

--- a/docs/guide/network.rst
+++ b/docs/guide/network.rst
@@ -134,8 +134,24 @@ Private key network operations use :class:`~bitcash.network.NetworkAPI`. For eac
 it polls a service and if an error occurs it tries another.
 
 .. note::
-   Default chaingraph APIs do not indicate if a transaction broadcast has failed. The NetworkAPI fallbacks to 
+   Default chaingraph APIs do not indicate if a transaction broadcast has failed. The NetworkAPI fallbacks to
    FulcrumProtocolAPI on ``mainnet`` to broadcast a transaction.
+
+Exceptions
+^^^^^^^^^^
+
+Endpoint methods may raise two kinds of errors that are handled differently by
+NetworkAPI:
+
+- :class:`~bitcash.exceptions.InvalidEndpointResponse` — the endpoint returned
+  an application-level error (e.g. GraphQL ``errors`` field, JSON-RPC error).
+  This is added to ``NetworkAPI.IGNORED_ERRORS``, so the endpoint is skipped
+  and the next one is tried.
+
+- :class:`~bitcash.exceptions.DataNotFound` — the requested data (transaction,
+  output) does not exist on the endpoint. This is **not** an ignored error, so
+  it propagates immediately to the caller. This avoids masking genuinely missing
+  data behind a ``ConnectionError("All APIs are unreachable")`` message.
 
 .. _satoshi: https://en.bitcoin.it/wiki/Satoshi_(unit)
 .. _blockchain: https://en.bitcoin.it/wiki/Block_chain

--- a/tests/network/APIs/test_ChaingraphAPI.py
+++ b/tests/network/APIs/test_ChaingraphAPI.py
@@ -1,6 +1,7 @@
 import pytest
 from bitcash.network.APIs import ChaingraphAPI as _capi
 
+from bitcash.exceptions import DataNotFound
 from bitcash.network.transaction import Transaction, TxPart
 from bitcash.network.APIs.ChaingraphAPI import ChaingraphAPI
 from bitcash.network.meta import Unspent
@@ -328,7 +329,7 @@ class TestChaingraphAPI:
         # zero return
         return_json = {"data": {"output": []}}
         monkeypatch.setattr(_capi, "session", DummySession(return_json))
-        with pytest.raises(RuntimeError):
+        with pytest.raises(DataNotFound):
             # a tx that does not exist
             amount = self.api.get_tx_amount(
                 "546f83e975d2870de740917df1b5221aa4bc52c6e2540188f5897c4ce775b7f4", 0
@@ -483,7 +484,7 @@ class TestChaingraphAPI:
         # zero return
         return_json = {"data": {"transaction": []}}
         monkeypatch.setattr(_capi, "session", DummySession(return_json))
-        with pytest.raises(RuntimeError):
+        with pytest.raises(DataNotFound):
             # a tx that does not exist
             tx = self.api.get_raw_transaction(
                 "546f83e975d2870de740917df1b5221aa4bc52c6e2540188f5897c4ce775b7f4",


### PR DESCRIPTION
# Description
Guard against unreliable endpoints that return empty data or application-level errors (e.g. GraphQL returning 200 with `"errors"` in the body, or `"block": []` for unsynced nodes). Fixes #146.

## Changes
- Fix `ChaingraphAPI.get_blockheight` to return 0 when no blocks are indexed, so NetworkAPI's endpoint selection skips unsynced nodes
- Add `InvalidEndpointResponse` exception for application-level errors (GraphQL `"errors"` field, JSON-RPC errors), added to `NetworkAPI.IGNORED_ERRORS` so the endpoint is skipped
- Add `DataNotFound` exception for missing transactions/outputs, not added to `IGNORED_ERRORS` so it propagates to the caller instead of a misleading "All APIs are unreachable"
- Replace all generic `RuntimeError` raises in `ChaingraphAPI` and `FulcrumProtocolAPI` with the appropriate specific exception
- Document both exception types in `BaseAPI`, `NetworkAPI`, and `docs/guide/network.rst`