### PR TITLE
Align opcodes and token commitment length with HF2026 spec

### DIFF
--- a/bitcash/op.py
+++ b/bitcash/op.py
@@ -111,8 +111,8 @@ class OpCodes(IntEnum):
     OP_VER = 0x62
     OP_IF = 0x63
     OP_NOTIF = 0x64
-    OP_VERIF = 0x65
-    OP_VERNOTIF = 0x66
+    OP_BEGIN = 0x65
+    OP_UNTIL = 0x66
     OP_ELSE = 0x67
     OP_ENDIF = 0x68
     OP_VERIFY = 0x69
@@ -153,14 +153,18 @@ class OpCodes(IntEnum):
     OP_XOR = 0x86
     OP_EQUAL = 0x87
     OP_EQUALVERIFY = 0x88
-    OP_RESERVED1 = 0x89
-    OP_RESERVED2 = 0x8A
+    OP_LSHIFTBIN = 0x98
+    OP_RSHIFTBIN = 0x99
+
+    # user-defined functions
+    OP_DEFINE = 0x89
+    OP_INVOKE = 0x8A
 
     # numeric
     OP_1ADD = 0x8B
     OP_1SUB = 0x8C
-    OP_2MUL = 0x8D
-    OP_2DIV = 0x8E
+    OP_LSHIFTNUM = 0x8D
+    OP_RSHIFTNUM = 0x8E
     OP_NEGATE = 0x8F
     OP_ABS = 0x90
     OP_NOT = 0x91
@@ -171,8 +175,6 @@ class OpCodes(IntEnum):
     OP_MUL = 0x95
     OP_DIV = 0x96
     OP_MOD = 0x97
-    OP_LSHIFT = 0x98
-    OP_RSHIFT = 0x99
 
     OP_BOOLAND = 0x9A
     OP_BOOLOR = 0x9B

--- a/bitcash/types.py
+++ b/bitcash/types.py
@@ -7,7 +7,7 @@ import typing
 
 from bitcash.exceptions import InvalidCashToken
 
-COMMITMENT_LENGTH = 40
+COMMITMENT_LENGTH = 128
 MAX_TOKEN_AMOUNT = 9223372036854775807
 
 


### PR DESCRIPTION
Aligns `bitcash` with the four CHIPs adopted in the May 2026 BCH upgrade. `bitcash` is a wallet (not a VM), so the only library-visible surface is the opcode table in `bitcash/op.py` and the token commitment limit in `bitcash/types.py`. VM behavior and node-level consensus changes are out of scope.

### [Loops CHIP](https://github.com/bitjson/bch-loops)
Repurposes two previously-disabled codepoints as the `OP_BEGIN` / `OP_UNTIL` loop primitives:
- `OP_VERIF` (0x65) → `OP_BEGIN`
- `OP_VERNOTIF` (0x66) → `OP_UNTIL`

### [Functions CHIP](https://github.com/bitjson/bch-functions)
Repurposes two reserved codepoints to enable user-defined function definition/invocation:
- `OP_RESERVED1` (0x89) → `OP_DEFINE`
- `OP_RESERVED2` (0x8a) → `OP_INVOKE`

### [Pay-to-Script CHIP](https://github.com/bitjson/bch-p2s)
The only wallet-visible change from this CHIP is the token commitment length increase. Standardness rule changes (≤201-byte locking bytecode, removal of `MAX_TX_IN_SCRIPT_SIG_SIZE`) are node-level and need no wallet change.
- `COMMITMENT_LENGTH` raised from 40 → 128 bytes in `bitcash/types.py`

### [Bitwise CHIP](https://github.com/bitjson/bch-bitwise)
Enables five bitwise opcodes. `OP_INVERT` (0x83) was already correctly named; the other four are renamed from their disabled BTC names:
- `OP_2MUL` (0x8d) → `OP_LSHIFTNUM` (arithmetic shift, stays in `# numeric`)
- `OP_2DIV` (0x8e) → `OP_RSHIFTNUM` (arithmetic shift, stays in `# numeric`)
- `OP_LSHIFT` (0x98) → `OP_LSHIFTBIN` (logical shift, in `# bit logic`)
- `OP_RSHIFT` (0x99) → `OP_RSHIFTBIN` (logical shift, in `# bit logic`)